### PR TITLE
fix: rasterタイルソースの minzoom 未定義エラーを修正 (#75)

### DIFF
--- a/src/components/AddSourceModal/AddSourceModal.tsx
+++ b/src/components/AddSourceModal/AddSourceModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Modal, Space, Select, Input, message } from 'antd';
 import type { SourceSpecification } from 'maplibre-gl';
+import { sanitizeSourceSpec } from '../../utils/sanitizeSourceSpec';
 
 const SOURCE_TYPES = [
   { label: 'vector', value: 'vector' },
@@ -47,8 +48,9 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
       return;
     }
     const { sourceId, ...sourceSpec } = newSource;
-    console.log('追加するソース:', sourceId, sourceSpec, newSource);
-    onOk(sourceId, sourceSpec as SourceSpecification);
+    const sanitized = sanitizeSourceSpec(sourceSpec);
+    console.log('追加するソース:', sourceId, sanitized, newSource);
+    onOk(sourceId, sanitized as SourceSpecification);
     setNewSource(initialState);
   };
 

--- a/src/utils/sanitizeSourceSpec.ts
+++ b/src/utils/sanitizeSourceSpec.ts
@@ -1,0 +1,14 @@
+/**
+ * SourceSpecification からundefined値のプロパティを除去する。
+ * MapLibre GL JS はソース定義に undefined 値があるとバリデーションエラーを出すため、
+ * ユーザー入力からソースを作成する際にこの関数でサニタイズする。
+ */
+export function sanitizeSourceSpec<T extends Record<string, unknown>>(source: T): T {
+  const result = {} as Record<string, unknown>;
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}

--- a/tests/utils/sanitizeSourceSpec.test.ts
+++ b/tests/utils/sanitizeSourceSpec.test.ts
@@ -1,0 +1,61 @@
+import { sanitizeSourceSpec } from '../../src/utils/sanitizeSourceSpec';
+
+describe('sanitizeSourceSpec', () => {
+  test('undefined値のプロパティを除去する', () => {
+    const input = {
+      type: 'raster' as const,
+      tiles: ['https://example.com/{z}/{x}/{y}.png'],
+      minzoom: undefined,
+      maxzoom: undefined,
+    };
+    const result = sanitizeSourceSpec(input);
+    expect(result).toEqual({
+      type: 'raster',
+      tiles: ['https://example.com/{z}/{x}/{y}.png'],
+    });
+    expect('minzoom' in result).toBe(false);
+    expect('maxzoom' in result).toBe(false);
+  });
+
+  test('数値が指定されている場合はそのまま保持する', () => {
+    const input = {
+      type: 'raster' as const,
+      tiles: ['https://example.com/{z}/{x}/{y}.png'],
+      minzoom: 0,
+      maxzoom: 22,
+    };
+    const result = sanitizeSourceSpec(input);
+    expect(result).toEqual({
+      type: 'raster',
+      tiles: ['https://example.com/{z}/{x}/{y}.png'],
+      minzoom: 0,
+      maxzoom: 22,
+    });
+  });
+
+  test('すべての値が定義されている場合は変更しない', () => {
+    const input = {
+      type: 'vector' as const,
+      url: 'https://example.com/tiles.json',
+      attribution: '&copy; Test',
+    };
+    const result = sanitizeSourceSpec(input);
+    expect(result).toEqual(input);
+  });
+
+  test('空文字列やnullは除去しない（undefinedのみ除去）', () => {
+    const input = {
+      type: 'raster' as const,
+      url: '',
+      attribution: '',
+      minzoom: undefined,
+    };
+    const result = sanitizeSourceSpec(input);
+    expect(result).toEqual({
+      type: 'raster',
+      url: '',
+      attribution: '',
+    });
+    expect('minzoom' in result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- rasterタイルソース追加時に `minzoom`/`maxzoom` が `undefined` のままスタイルに渡され、MapLibre GL JS がバリデーションエラー（`sources.satellite.minzoom: number expected, undefined found`）を出す問題を修正
- `sanitizeSourceSpec` ユーティリティ関数を新設し、`AddSourceModal` の `handleOk` で `undefined` プロパティを除去してからソースを追加するようにした
- ユニットテスト 4件追加（undefined除去、数値保持、全値定義済み、空文字列保持）

Closes #75

## Test plan
- [x] `sanitizeSourceSpec` のユニットテストが全件パス
- [x] `npm run build` が成功
- [x] `npm run lint` で新規ファイルにエラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * モーダルダイアログで送信されるデータをクリーニングし、データの品質を向上させました

* **テスト**
  * データ処理機能の単体テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->