### PR TITLE
feat: 新規ソース追加時にレイヤーへ自動カラー付与 (#72)

### DIFF
--- a/src/components/StyleEditor/StyleEditor.tsx
+++ b/src/components/StyleEditor/StyleEditor.tsx
@@ -16,6 +16,7 @@ import BasicInfo from '../BasicInfo/BasicInfo';
 import LayerEditor from '../LayerEditor/LayerEditor';
 import SourceEditor from '../SourceEditor/SourceEditor';
 import AddLayerModal from '../AddLayerModal/AddLayerModal';
+import { generateColorByIndex, generatePaintWithAutoColor } from '../../utils/generateAutoColor';
 
 const { Sider, Content } = Layout;
 const { Title, Text } = Typography;
@@ -45,6 +46,18 @@ const StyleEditor: React.FC = () => {
   const handleAddLayerOk = () => {
     addLayerForm.validateFields().then(values => {
       if (!style || typeof style === 'string') { return; }
+
+      // ユーザーが paint を指定していない場合、自動で色を付与する
+      const existingLayerCount = style?.layers?.length ?? 0;
+      const layerType = addLayerGroupType ?? 'fill';
+      let paint: Record<string, unknown>;
+      if (values.paint) {
+        paint = JSON.parse(values.paint);
+      } else {
+        const autoColor = generateColorByIndex(existingLayerCount);
+        paint = generatePaintWithAutoColor(layerType, autoColor);
+      }
+
       const newLayer = {
         id: values.id,
         type: addLayerGroupType,
@@ -52,7 +65,7 @@ const StyleEditor: React.FC = () => {
         'source-layer': values.sourceLayer,
         layout: values.layout ? JSON.parse(values.layout) : {},
         filter: values.filter ? JSON.parse(values.filter) : undefined,
-        paint: values.paint ? JSON.parse(values.paint) : {},
+        paint,
       };
       const newStyle = {
         ...style,

--- a/src/utils/generateAutoColor.ts
+++ b/src/utils/generateAutoColor.ts
@@ -1,0 +1,80 @@
+import { hslToHex } from './colorHelpers';
+
+/**
+ * 文字列からハッシュ値を生成する（maplibre-gl-inspect のアプローチに基づく）
+ * 同じ文字列からは常に同じハッシュが生成される
+ */
+export function stringHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * レイヤーIDからユニークなカラーを生成する
+ * ハッシュベースで色相を決定し、彩度・明度を固定して見やすい色を生成する
+ */
+export function generateColorFromLayerId(layerId: string): string {
+  const hash = stringHash(layerId);
+  const hue = hash % 360;
+  const saturation = 0.7;
+  const lightness = 0.5;
+  return hslToHex(hue, saturation, lightness);
+}
+
+/**
+ * インデックスベースで色を生成する（既存レイヤー数に基づく）
+ * 黄金角（~137.5度）を使って色相を均等に分散させる
+ */
+export function generateColorByIndex(index: number): string {
+  const goldenAngle = 137.508;
+  const hue = (index * goldenAngle) % 360;
+  const saturation = 0.65;
+  const lightness = 0.5;
+  return hslToHex(hue, saturation, lightness);
+}
+
+/**
+ * レイヤータイプに応じた paint プロパティに色を設定する
+ */
+export function generatePaintWithAutoColor(
+  layerType: string,
+  color: string
+): Record<string, unknown> {
+  switch (layerType) {
+    case 'fill':
+      return {
+        'fill-color': color,
+        'fill-opacity': 0.6,
+      };
+    case 'line':
+      return {
+        'line-color': color,
+        'line-width': 2,
+      };
+    case 'circle':
+      return {
+        'circle-color': color,
+        'circle-radius': 5,
+      };
+    case 'symbol':
+      return {
+        'text-color': color,
+      };
+    case 'fill-extrusion':
+      return {
+        'fill-extrusion-color': color,
+        'fill-extrusion-opacity': 0.6,
+      };
+    case 'heatmap':
+      return {
+        'heatmap-color': color,
+      };
+    default:
+      return {};
+  }
+}

--- a/tests/utils/generateAutoColor.test.ts
+++ b/tests/utils/generateAutoColor.test.ts
@@ -1,0 +1,128 @@
+import {
+  stringHash,
+  generateColorFromLayerId,
+  generateColorByIndex,
+  generatePaintWithAutoColor,
+} from '../../src/utils/generateAutoColor';
+
+describe('stringHash', () => {
+  it('同じ文字列からは同じハッシュ値が生成される', () => {
+    expect(stringHash('test-layer')).toBe(stringHash('test-layer'));
+  });
+
+  it('異なる文字列からは異なるハッシュ値が生成される', () => {
+    expect(stringHash('layer-a')).not.toBe(stringHash('layer-b'));
+  });
+
+  it('空文字列からは0が返される', () => {
+    expect(stringHash('')).toBe(0);
+  });
+
+  it('常に正の値が返される', () => {
+    const testStrings = ['abc', 'xyz', 'long-layer-name-with-many-characters', '日本語'];
+    for (const str of testStrings) {
+      expect(stringHash(str)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('generateColorFromLayerId', () => {
+  it('有効なHEXカラーコードを返す', () => {
+    const color = generateColorFromLayerId('my-layer');
+    expect(color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('同じIDからは同じ色が生成される', () => {
+    const color1 = generateColorFromLayerId('test-layer');
+    const color2 = generateColorFromLayerId('test-layer');
+    expect(color1).toBe(color2);
+  });
+
+  it('異なるIDからは異なる色が生成される', () => {
+    const color1 = generateColorFromLayerId('layer-a');
+    const color2 = generateColorFromLayerId('layer-b');
+    expect(color1).not.toBe(color2);
+  });
+});
+
+describe('generateColorByIndex', () => {
+  it('有効なHEXカラーコードを返す', () => {
+    const color = generateColorByIndex(0);
+    expect(color).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it('異なるインデックスからは異なる色が生成される', () => {
+    const colors = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      colors.add(generateColorByIndex(i));
+    }
+    // 10色すべてが異なることを確認
+    expect(colors.size).toBe(10);
+  });
+
+  it('同じインデックスからは同じ色が生成される', () => {
+    expect(generateColorByIndex(5)).toBe(generateColorByIndex(5));
+  });
+
+  it('隣接するインデックスの色が十分に離れている', () => {
+    // 黄金角を使っているので隣接する色は大きく離れるはず
+    const color0 = generateColorByIndex(0);
+    const color1 = generateColorByIndex(1);
+    expect(color0).not.toBe(color1);
+  });
+});
+
+describe('generatePaintWithAutoColor', () => {
+  const testColor = '#ff0000';
+
+  it('fill タイプに対して fill-color と fill-opacity を設定する', () => {
+    const paint = generatePaintWithAutoColor('fill', testColor);
+    expect(paint).toEqual({
+      'fill-color': testColor,
+      'fill-opacity': 0.6,
+    });
+  });
+
+  it('line タイプに対して line-color と line-width を設定する', () => {
+    const paint = generatePaintWithAutoColor('line', testColor);
+    expect(paint).toEqual({
+      'line-color': testColor,
+      'line-width': 2,
+    });
+  });
+
+  it('circle タイプに対して circle-color と circle-radius を設定する', () => {
+    const paint = generatePaintWithAutoColor('circle', testColor);
+    expect(paint).toEqual({
+      'circle-color': testColor,
+      'circle-radius': 5,
+    });
+  });
+
+  it('symbol タイプに対して text-color を設定する', () => {
+    const paint = generatePaintWithAutoColor('symbol', testColor);
+    expect(paint).toEqual({
+      'text-color': testColor,
+    });
+  });
+
+  it('fill-extrusion タイプに対して fill-extrusion-color と fill-extrusion-opacity を設定する', () => {
+    const paint = generatePaintWithAutoColor('fill-extrusion', testColor);
+    expect(paint).toEqual({
+      'fill-extrusion-color': testColor,
+      'fill-extrusion-opacity': 0.6,
+    });
+  });
+
+  it('heatmap タイプに対して heatmap-color を設定する', () => {
+    const paint = generatePaintWithAutoColor('heatmap', testColor);
+    expect(paint).toEqual({
+      'heatmap-color': testColor,
+    });
+  });
+
+  it('未知のタイプに対しては空オブジェクトを返す', () => {
+    const paint = generatePaintWithAutoColor('unknown', testColor);
+    expect(paint).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- 新規レイヤー追加時に paint プロパティが未指定の場合、自動で見やすい色を付与する機能を追加
- 黄金角（~137.5度）による色相分散アルゴリズムで、既存レイヤー数に基づいた視覚的に区別しやすい色を生成
- レイヤータイプ（fill, line, circle, symbol, fill-extrusion, heatmap）に応じた適切な paint プロパティを自動設定
- maplibre-gl-inspect のハッシュベースカラー生成アプローチにインスパイアされた実装（外部依存なし）

Closes #72

## Test plan
- [x] `generateAutoColor.ts` のユニットテスト 18 件全パス
  - stringHash: 決定性、一意性、空文字列、正値の検証
  - generateColorFromLayerId: HEX形式、決定性、一意性の検証
  - generateColorByIndex: HEX形式、10色の一意性、決定性の検証
  - generatePaintWithAutoColor: 各レイヤータイプ（fill/line/circle/symbol/fill-extrusion/heatmap/unknown）の paint 生成検証
- [x] TypeScript ビルド成功
- [x] ESLint エラーなし（変更ファイルのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レイヤー追加時に自動色生成機能を導入。新しいレイヤーはレイヤーのインデックスに基づいて自動的に固有の色を割り当てられるようになり、レイヤー作成時の利便性が向上します。

* **テスト**
  * 自動色生成機能の包括的なテストスイートを追加。色の一貫性、決定論性、多様性を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->