### PR TITLE
feat: タイルURLからsource-layerを自動取得 (#15)

### DIFF
--- a/src/components/AddLayerModal/AddLayerModal.tsx
+++ b/src/components/AddLayerModal/AddLayerModal.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { Modal, Form, Input, Select, type FormInstance } from 'antd';
-import type { LayerSpecification } from 'maplibre-gl';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, Form, Input, Select, Button, Space, Typography, type FormInstance } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+import type { LayerSpecification, SourceSpecification } from 'maplibre-gl';
+import { useSourceLayers } from '../../hooks/useSourceLayers';
+
+const { Text } = Typography;
 
 type AddLayerModalProps = {
   open: boolean;
@@ -9,6 +13,7 @@ type AddLayerModalProps = {
   onOk: () => void;
   onCancel: () => void;
   layers: LayerSpecification[];
+  sources?: Record<string, SourceSpecification>;
 };
 
 const AddLayerModal: React.FC<AddLayerModalProps> = ({
@@ -17,91 +22,158 @@ const AddLayerModal: React.FC<AddLayerModalProps> = ({
   onOk,
   onCancel,
   layers,
-}) => (
-  <Modal
-    open={open}
-    title="新規レイヤーを追加"
-    onOk={onOk}
-    onCancel={onCancel}
-    okText="追加"
-    cancelText="キャンセル"
-  >
-    <Form form={form} layout="vertical">
-      <Form.Item
-        label="既存レイヤーからコピー"
-        name="copyLayerId"
-        tooltip="既存レイヤーを選択すると、その内容をコピーして編集できます"
-      >
-        <Select
-          allowClear
-          placeholder="コピー元レイヤーを選択"
-          onChange={layerId => {
-            const layer = layers.find(l => l.id === layerId);
-            if (layer) {
-              console.log('コピーするレイヤー:', (layer as { 'source-layer': string })['source-layer']);
-              // コピー内容をフォームにセット
-              form.setFieldsValue({
-                id: `${layer.id}_copy`,
-                source: 'source' in layer ? (layer as { source: string }).source : '',
-                sourceLayer: (layer as { 'source-layer': string })['source-layer'] ?? '',
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                filter: 'filter' in layer && (layer as any).filter ? JSON.stringify((layer as any).filter, null, 2) : '',
-                paint: layer.paint ? JSON.stringify(layer.paint, null, 2) : '',
-                layout: layer.layout ? JSON.stringify(layer.layout, null, 2) : '',
-              });
-            }
-          }}
+  sources,
+}) => {
+  const [selectedSourceUrl, setSelectedSourceUrl] = useState('');
+  const { layers: sourceLayers, loading: sourceLayersLoading, error: sourceLayersError, fetchLayers } = useSourceLayers(selectedSourceUrl);
+
+  // source が選択されたときに URL を取得する
+  const handleSourceChange = useCallback((sourceId: string) => {
+    form.setFieldsValue({ source: sourceId, sourceLayer: '' });
+    if (sources && sourceId && sources[sourceId]) {
+      const src = sources[sourceId];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const url = (src as any).url || '';
+      setSelectedSourceUrl(url);
+    } else {
+      setSelectedSourceUrl('');
+    }
+  }, [sources, form]);
+
+  // モーダルが閉じたらリセット
+  useEffect(() => {
+    if (!open) {
+      setSelectedSourceUrl('');
+    }
+  }, [open]);
+
+  const sourceOptions = sources
+    ? Object.keys(sources).map(id => ({ label: id, value: id }))
+    : [];
+
+  return (
+    <Modal
+      open={open}
+      title="新規レイヤーを追加"
+      onOk={onOk}
+      onCancel={onCancel}
+      okText="追加"
+      cancelText="キャンセル"
+    >
+      <Form form={form} layout="vertical">
+        <Form.Item
+          label="既存レイヤーからコピー"
+          name="copyLayerId"
+          tooltip="既存レイヤーを選択すると、その内容をコピーして編集できます"
         >
-          {layers && layers.map(layer => (
-            <Select.Option key={layer.id} value={layer.id}>
-              {layer.id}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-      <Form.Item
-        label="レイヤーID"
-        name="id"
-        rules={[{ required: true, message: 'レイヤーIDを入力してください' }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="source"
-        name="source"
-        rules={[{ required: true, message: 'sourceを入力してください' }]}
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="source-layer"
-        name="sourceLayer"
-      >
-        <Input />
-      </Form.Item>
-      <Form.Item
-        label="filter (JSON形式)"
-        name="filter"
-        tooltip='例: ["==", "class", "A"]'
-      >
-        <Input.TextArea rows={2} placeholder='["==", "class", "A"]' />
-      </Form.Item>
-      <Form.Item
-        label="paint (JSON形式)"
-        name="paint"
-        tooltip='例: {"circle-color": "#ff0000"}'
-      >
-        <Input.TextArea rows={2} placeholder='{"circle-color": "#ff0000"}' />
-      </Form.Item>
-      <Form.Item
-        label="layout (JSON形式)"
-        name="layout"
-        tooltip='例: {"icon-image": "my-icon"}'
-      >
-        <Input.TextArea rows={2} placeholder='{"icon-image": "my-icon"}' />
-      </Form.Item>
-    </Form>
-  </Modal>
-);
+          <Select
+            allowClear
+            placeholder="コピー元レイヤーを選択"
+            onChange={layerId => {
+              const layer = layers.find(l => l.id === layerId);
+              if (layer) {
+                console.log('コピーするレイヤー:', (layer as { 'source-layer': string })['source-layer']);
+                // コピー内容をフォームにセット
+                form.setFieldsValue({
+                  id: `${layer.id}_copy`,
+                  source: 'source' in layer ? (layer as { source: string }).source : '',
+                  sourceLayer: (layer as { 'source-layer': string })['source-layer'] ?? '',
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  filter: 'filter' in layer && (layer as any).filter ? JSON.stringify((layer as any).filter, null, 2) : '',
+                  paint: layer.paint ? JSON.stringify(layer.paint, null, 2) : '',
+                  layout: layer.layout ? JSON.stringify(layer.layout, null, 2) : '',
+                });
+              }
+            }}
+          >
+            {layers && layers.map(layer => (
+              <Select.Option key={layer.id} value={layer.id}>
+                {layer.id}
+              </Select.Option>
+            ))}
+          </Select>
+        </Form.Item>
+        <Form.Item
+          label="レイヤーID"
+          name="id"
+          rules={[{ required: true, message: 'レイヤーIDを入力してください' }]}
+        >
+          <Input />
+        </Form.Item>
+        <Form.Item
+          label="source"
+          name="source"
+          rules={[{ required: true, message: 'sourceを入力してください' }]}
+        >
+          {sourceOptions.length > 0 ? (
+            <Select
+              allowClear
+              showSearch
+              placeholder="sourceを選択または入力"
+              options={sourceOptions}
+              onChange={handleSourceChange}
+            />
+          ) : (
+            <Input />
+          )}
+        </Form.Item>
+        <Form.Item
+          label="source-layer"
+          name="sourceLayer"
+        >
+          {sourceLayers.length > 0 ? (
+            <Select
+              allowClear
+              showSearch
+              placeholder="source-layerを選択"
+              options={sourceLayers.map(id => ({ label: id, value: id }))}
+            />
+          ) : (
+            <Space.Compact style={{ width: '100%' }}>
+              <Input placeholder="source-layerを入力" />
+              {selectedSourceUrl && (
+                <Button
+                  type="default"
+                  icon={<SearchOutlined />}
+                  loading={sourceLayersLoading}
+                  onClick={fetchLayers}
+                  aria-label="source-layerを取得"
+                >
+                  取得
+                </Button>
+              )}
+            </Space.Compact>
+          )}
+        </Form.Item>
+        {sourceLayersError && (
+          <Text type="danger" style={{ fontSize: 12, display: 'block', marginBottom: 12 }}>
+            {sourceLayersError}
+          </Text>
+        )}
+        <Form.Item
+          label="filter (JSON形式)"
+          name="filter"
+          tooltip='例: ["==", "class", "A"]'
+        >
+          <Input.TextArea rows={2} placeholder='["==", "class", "A"]' />
+        </Form.Item>
+        <Form.Item
+          label="paint (JSON形式)"
+          name="paint"
+          tooltip='例: {"circle-color": "#ff0000"}'
+        >
+          <Input.TextArea rows={2} placeholder='{"circle-color": "#ff0000"}' />
+        </Form.Item>
+        <Form.Item
+          label="layout (JSON形式)"
+          name="layout"
+          tooltip='例: {"icon-image": "my-icon"}'
+        >
+          <Input.TextArea rows={2} placeholder='{"icon-image": "my-icon"}' />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
 
 export default AddLayerModal;

--- a/src/components/AddSourceModal/AddSourceModal.tsx
+++ b/src/components/AddSourceModal/AddSourceModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import { Modal, Space, Select, Input, message } from 'antd';
+import { Modal, Space, Select, Input, message, Button, Tag, Spin, Typography } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
 import type { SourceSpecification } from 'maplibre-gl';
+import { useSourceLayers } from '../../hooks/useSourceLayers';
 
 const SOURCE_TYPES = [
   { label: 'vector', value: 'vector' },
@@ -27,8 +29,11 @@ const initialState = {
   maxzoom: undefined,
 };
 
+const { Text } = Typography;
+
 const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel }) => {
   const [newSource, setNewSource] = useState(initialState);
+  const { layers: sourceLayers, loading: sourceLayersLoading, error: sourceLayersError, fetchLayers } = useSourceLayers(newSource.url);
 
   const handleChange = (key: string, value: string | number | string[] | undefined) => {
     setNewSource(prev => ({
@@ -51,6 +56,11 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
     onOk(sourceId, sourceSpec as SourceSpecification);
     setNewSource(initialState);
   };
+
+  const showUrlField = newSource.type !== 'video';
+  const showTilesField = newSource.type !== 'geojson' && newSource.type !== 'image';
+  const isVectorType = newSource.type === 'vector';
+  const hasUrl = newSource.url.trim().length > 0;
 
   return (
     <Modal
@@ -80,15 +90,51 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
             allowClear
           />
         </div>
-        {(newSource.type !== 'video') && (
-          <Input
-            addonBefore={newSource.type === 'geojson' ? "data" : "url"}
-            placeholder={"url" + (newSource.type === 'geojson' ? "またはdataを指定" : "")}
-            value={newSource.url ?? ''}
-            onChange={e => handleChange('url', e.target.value)}
-          />
+        {showUrlField && (
+          <Space.Compact style={{ width: '100%' }}>
+            <Input
+              addonBefore={newSource.type === 'geojson' ? "data" : "url"}
+              placeholder={"url" + (newSource.type === 'geojson' ? "またはdataを指定" : "")}
+              value={newSource.url ?? ''}
+              onChange={e => handleChange('url', e.target.value)}
+            />
+            {isVectorType && (
+              <Button
+                type="primary"
+                icon={<SearchOutlined />}
+                loading={sourceLayersLoading}
+                disabled={!hasUrl}
+                onClick={fetchLayers}
+                aria-label="source-layerを取得"
+              >
+                取得
+              </Button>
+            )}
+          </Space.Compact>
         )}
-        {(newSource.type !== 'geojson' && newSource.type !== 'image') && (
+        {isVectorType && sourceLayers.length > 0 && (
+          <div>
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              取得された source-layer ({sourceLayers.length}件):
+            </Text>
+            <div style={{ marginTop: 4 }}>
+              {sourceLayers.map(layer => (
+                <Tag key={layer} color="blue" style={{ marginBottom: 4 }}>
+                  {layer}
+                </Tag>
+              ))}
+            </div>
+          </div>
+        )}
+        {isVectorType && sourceLayersLoading && (
+          <Spin size="small" />
+        )}
+        {isVectorType && sourceLayersError && (
+          <Text type="danger" style={{ fontSize: 12 }}>
+            {sourceLayersError}
+          </Text>
+        )}
+        {showTilesField && (
           <Input
             addonBefore={newSource.type === 'video' ? "urls" : "tiles"}
             placeholder="カンマ区切りで複数指定"

--- a/src/components/StyleEditor/StyleEditor.tsx
+++ b/src/components/StyleEditor/StyleEditor.tsx
@@ -191,7 +191,8 @@ const StyleEditor: React.FC = () => {
         onOk={handleAddLayerOk}
         onCancel={handleAddLayerCancel}
         form={addLayerForm} 
-        layers={style && typeof style !== 'string' ? style?.layers : []} 
+        layers={style && typeof style !== 'string' ? style?.layers : []}
+        sources={style && typeof style !== 'string' ? style?.sources : undefined}
       />
     </Layout>
   );

--- a/src/hooks/useSourceLayers.ts
+++ b/src/hooks/useSourceLayers.ts
@@ -1,27 +1,27 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
+import { fetchSourceLayers } from "../lib/fetchSourceLayers";
 
 export function useSourceLayers(url: string) {
   const [loading, setLoading] = useState(false);
   const [layers, setLayers] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchLayers = async () => {
+  const fetchLayers = useCallback(async () => {
+    if (!url.trim()) {
+      setError('URLを入力してください');
+      return;
+    }
     setLoading(true);
     setError(null);
+    setLayers([]);
     try {
-      const res = await fetch(url);
-      const data = await res.json();
-      if (data.vector_layers) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setLayers(data.vector_layers.map((l: any) => l.id));
-      } else {
-        setError('vector_layersが見つかりません');
-      }
+      const result = await fetchSourceLayers(url);
+      setLayers(result);
     } catch (e) {
-      setError(`取得に失敗しました。${e}`);
+      setError(e instanceof Error ? e.message : `取得に失敗しました: ${e}`);
     }
     setLoading(false);
-  };
+  }, [url]);
 
   return { layers, loading, error, fetchLayers };
 }

--- a/src/lib/fetchSourceLayers.ts
+++ b/src/lib/fetchSourceLayers.ts
@@ -1,0 +1,73 @@
+/**
+ * TileJSON レスポンスから vector_layers の id を抽出するユーティリティ
+ */
+
+export type TileJsonResponse = {
+  vector_layers?: { id: string; [key: string]: unknown }[];
+  [key: string]: unknown;
+};
+
+/**
+ * TileJSON レスポンスから source-layer の ID 一覧を抽出する
+ */
+export function extractSourceLayerIds(tileJson: TileJsonResponse): string[] {
+  if (!tileJson.vector_layers || !Array.isArray(tileJson.vector_layers)) {
+    return [];
+  }
+  return tileJson.vector_layers
+    .map((layer) => layer.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+/**
+ * タイル URL を正規化して TileJSON エンドポイントの候補を返す
+ * - URL がそのまま TileJSON を返す場合がある
+ * - URL に /tilejson.json を付加して TileJSON を返す場合がある
+ */
+export function buildTileJsonUrls(url: string): string[] {
+  const trimmed = url.trim();
+  if (!trimmed) return [];
+
+  const urls: string[] = [trimmed];
+
+  // 末尾が .json でなければ /tilejson.json を追加した候補も返す
+  if (!trimmed.endsWith('.json')) {
+    const base = trimmed.endsWith('/') ? trimmed.slice(0, -1) : trimmed;
+    urls.push(`${base}/tilejson.json`);
+  }
+
+  return urls;
+}
+
+/**
+ * タイル URL から source-layer の一覧を取得する
+ * 複数の URL 候補を順番に試行し、最初に成功したものを返す
+ */
+export async function fetchSourceLayers(url: string): Promise<string[]> {
+  const urls = buildTileJsonUrls(url);
+  if (urls.length === 0) {
+    throw new Error('URLが空です');
+  }
+
+  let lastError: Error | null = null;
+
+  for (const candidateUrl of urls) {
+    try {
+      const res = await fetch(candidateUrl);
+      if (!res.ok) {
+        lastError = new Error(`HTTP ${res.status}: ${res.statusText}`);
+        continue;
+      }
+      const data: TileJsonResponse = await res.json();
+      const layers = extractSourceLayerIds(data);
+      if (layers.length > 0) {
+        return layers;
+      }
+      lastError = new Error('vector_layersが見つかりません');
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(String(e));
+    }
+  }
+
+  throw lastError ?? new Error('source-layerの取得に失敗しました');
+}

--- a/tests/hooks/useSourceLayers.test.ts
+++ b/tests/hooks/useSourceLayers.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from '@testing-library/react';
+import { useSourceLayers } from '../../src/hooks/useSourceLayers';
+
+describe('useSourceLayers', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('初期状態では layers が空、loading が false、error が null', () => {
+    const { result } = renderHook(() => useSourceLayers('https://example.com/tiles.json'));
+    expect(result.current.layers).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('fetchLayers で TileJSON から source-layer を取得できる', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        vector_layers: [
+          { id: 'water' },
+          { id: 'road' },
+        ],
+      }),
+    });
+
+    const { result } = renderHook(() => useSourceLayers('https://example.com/tiles.json'));
+
+    await act(async () => {
+      await result.current.fetchLayers();
+    });
+
+    expect(result.current.layers).toEqual(['water', 'road']);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('取得失敗時に error がセットされる', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useSourceLayers('https://example.com/tiles.json'));
+
+    await act(async () => {
+      await result.current.fetchLayers();
+    });
+
+    expect(result.current.layers).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe('Network error');
+  });
+
+  test('空の URL の場合はエラーメッセージをセットする', async () => {
+    const { result } = renderHook(() => useSourceLayers(''));
+
+    await act(async () => {
+      await result.current.fetchLayers();
+    });
+
+    expect(result.current.error).toBe('URLを入力してください');
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/tests/lib/fetchSourceLayers.test.ts
+++ b/tests/lib/fetchSourceLayers.test.ts
@@ -1,0 +1,144 @@
+import {
+  extractSourceLayerIds,
+  buildTileJsonUrls,
+  fetchSourceLayers,
+  TileJsonResponse,
+} from '../../src/lib/fetchSourceLayers';
+
+describe('extractSourceLayerIds', () => {
+  test('TileJSON の vector_layers から id を抽出する', () => {
+    const tileJson: TileJsonResponse = {
+      vector_layers: [
+        { id: 'water', fields: {} },
+        { id: 'road', fields: {} },
+        { id: 'building', fields: {} },
+      ],
+    };
+    expect(extractSourceLayerIds(tileJson)).toEqual(['water', 'road', 'building']);
+  });
+
+  test('vector_layers が空配列の場合は空配列を返す', () => {
+    expect(extractSourceLayerIds({ vector_layers: [] })).toEqual([]);
+  });
+
+  test('vector_layers がない場合は空配列を返す', () => {
+    expect(extractSourceLayerIds({})).toEqual([]);
+  });
+
+  test('vector_layers が配列でない場合は空配列を返す', () => {
+    expect(extractSourceLayerIds({ vector_layers: 'invalid' as unknown as TileJsonResponse['vector_layers'] })).toEqual([]);
+  });
+
+  test('id が空文字のレイヤーは除外する', () => {
+    const tileJson: TileJsonResponse = {
+      vector_layers: [
+        { id: 'water', fields: {} },
+        { id: '', fields: {} },
+        { id: 'road', fields: {} },
+      ],
+    };
+    expect(extractSourceLayerIds(tileJson)).toEqual(['water', 'road']);
+  });
+});
+
+describe('buildTileJsonUrls', () => {
+  test('JSON URL の場合はそのまま1つだけ返す', () => {
+    const urls = buildTileJsonUrls('https://example.com/tiles.json');
+    expect(urls).toEqual(['https://example.com/tiles.json']);
+  });
+
+  test('非 JSON URL の場合は元のURLと /tilejson.json 付きの2つを返す', () => {
+    const urls = buildTileJsonUrls('https://example.com/tiles');
+    expect(urls).toEqual([
+      'https://example.com/tiles',
+      'https://example.com/tiles/tilejson.json',
+    ]);
+  });
+
+  test('末尾スラッシュ付きの場合はスラッシュを除去して /tilejson.json を付加する', () => {
+    const urls = buildTileJsonUrls('https://example.com/tiles/');
+    expect(urls).toEqual([
+      'https://example.com/tiles/',
+      'https://example.com/tiles/tilejson.json',
+    ]);
+  });
+
+  test('空文字の場合は空配列を返す', () => {
+    expect(buildTileJsonUrls('')).toEqual([]);
+    expect(buildTileJsonUrls('  ')).toEqual([]);
+  });
+});
+
+describe('fetchSourceLayers', () => {
+  const mockTileJson: TileJsonResponse = {
+    tilejson: '3.0.0',
+    vector_layers: [
+      { id: 'water', fields: {} },
+      { id: 'road', fields: {} },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('TileJSON URL から source-layer を取得できる', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockTileJson),
+    });
+
+    const layers = await fetchSourceLayers('https://example.com/tiles.json');
+    expect(layers).toEqual(['water', 'road']);
+    expect(global.fetch).toHaveBeenCalledWith('https://example.com/tiles.json');
+  });
+
+  test('最初のURLが失敗した場合、/tilejson.json を付加して再試行する', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found' })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTileJson),
+      });
+
+    const layers = await fetchSourceLayers('https://example.com/tiles');
+    expect(layers).toEqual(['water', 'road']);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'https://example.com/tiles');
+    expect(global.fetch).toHaveBeenNthCalledWith(2, 'https://example.com/tiles/tilejson.json');
+  });
+
+  test('最初のURLで vector_layers がない場合、次の候補を試行する', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ name: 'some other json' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockTileJson),
+      });
+
+    const layers = await fetchSourceLayers('https://example.com/tiles');
+    expect(layers).toEqual(['water', 'road']);
+  });
+
+  test('全ての候補が失敗した場合はエラーを投げる', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+    await expect(fetchSourceLayers('https://example.com/tiles.json')).rejects.toThrow('Network error');
+  });
+
+  test('空の URL の場合はエラーを投げる', async () => {
+    await expect(fetchSourceLayers('')).rejects.toThrow('URLが空です');
+  });
+
+  test('全候補で vector_layers が見つからない場合はエラーを投げる', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ name: 'no vector layers' }),
+    });
+
+    await expect(fetchSourceLayers('https://example.com/tiles.json')).rejects.toThrow('vector_layersが見つかりません');
+  });
+});


### PR DESCRIPTION
## Summary

- タイルURLを指定すると TileJSON から `vector_layers` を取得し、利用可能な source-layer を自動表示する機能を追加
- `src/lib/fetchSourceLayers.ts` に純粋関数ユーティリティを新規作成（URL正規化、TileJSON解析、source-layer取得）
- `useSourceLayers` フックを `fetchSourceLayers` ユーティリティベースにリファクタリング（URL候補の自動試行に対応）
- AddSourceModal: vector タイプ選択時に「取得」ボタンを表示し、source-layer一覧をタグで表示
- AddLayerModal: ソースのドロップダウン選択と source-layer の自動取得・選択に対応

Closes #15

## Test plan

- [x] `fetchSourceLayers` ユーティリティの単体テスト（15件）: TileJSON解析、URL正規化、フェッチ試行、エラーハンドリング
- [x] `useSourceLayers` フックのテスト（4件）: 初期状態、正常取得、エラー、空URL
- [x] ビルド成功確認（`npm run build`）
- [x] Lint確認（新規コードにエラーなし）