### PR TITLE
feat: 入力値バリデーションの追加 (#26)

### DIFF
--- a/src/components/AddLayerModal/AddLayerModal.tsx
+++ b/src/components/AddLayerModal/AddLayerModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, Form, Input, Select, type FormInstance } from 'antd';
 import type { LayerSpecification } from 'maplibre-gl';
+import { validateJson } from '../../lib/validators';
 
 type AddLayerModalProps = {
   open: boolean;
@@ -83,6 +84,13 @@ const AddLayerModal: React.FC<AddLayerModalProps> = ({
         label="filter (JSON形式)"
         name="filter"
         tooltip='例: ["==", "class", "A"]'
+        rules={[{
+          validator: (_, value) => {
+            if (!value) return Promise.resolve();
+            const result = validateJson(value);
+            return result.valid ? Promise.resolve() : Promise.reject(new Error(result.message));
+          }
+        }]}
       >
         <Input.TextArea rows={2} placeholder='["==", "class", "A"]' />
       </Form.Item>
@@ -90,6 +98,13 @@ const AddLayerModal: React.FC<AddLayerModalProps> = ({
         label="paint (JSON形式)"
         name="paint"
         tooltip='例: {"circle-color": "#ff0000"}'
+        rules={[{
+          validator: (_, value) => {
+            if (!value) return Promise.resolve();
+            const result = validateJson(value);
+            return result.valid ? Promise.resolve() : Promise.reject(new Error(result.message));
+          }
+        }]}
       >
         <Input.TextArea rows={2} placeholder='{"circle-color": "#ff0000"}' />
       </Form.Item>
@@ -97,6 +112,13 @@ const AddLayerModal: React.FC<AddLayerModalProps> = ({
         label="layout (JSON形式)"
         name="layout"
         tooltip='例: {"icon-image": "my-icon"}'
+        rules={[{
+          validator: (_, value) => {
+            if (!value) return Promise.resolve();
+            const result = validateJson(value);
+            return result.valid ? Promise.resolve() : Promise.reject(new Error(result.message));
+          }
+        }]}
       >
         <Input.TextArea rows={2} placeholder='{"icon-image": "my-icon"}' />
       </Form.Item>

--- a/src/components/AddSourceModal/AddSourceModal.tsx
+++ b/src/components/AddSourceModal/AddSourceModal.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
-import { Modal, Space, Select, Input, message } from 'antd';
+import { Modal, Space, Select, Input, message, Typography } from 'antd';
 import type { SourceSpecification } from 'maplibre-gl';
+import { validateSourceId, validateUrl, validateTileUrl, validateZoomLevel } from '../../lib/validators';
+
+const { Text } = Typography;
 
 const SOURCE_TYPES = [
   { label: 'vector', value: 'vector' },
@@ -27,29 +30,87 @@ const initialState = {
   maxzoom: undefined,
 };
 
+type ValidationErrors = {
+  sourceId?: string;
+  url?: string;
+  tiles?: string;
+  minzoom?: string;
+  maxzoom?: string;
+};
+
 const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel }) => {
   const [newSource, setNewSource] = useState(initialState);
+  const [errors, setErrors] = useState<ValidationErrors>({});
 
   const handleChange = (key: string, value: string | number | string[] | undefined) => {
     setNewSource(prev => ({
       ...prev,
       [key]: value,
     }));
+    // 入力時にそのフィールドのエラーをクリア
+    setErrors(prev => ({ ...prev, [key]: undefined }));
   };
 
   const handleOk = () => {
+    const newErrors: ValidationErrors = {};
+
     if (!newSource.type) {
       message.error('typeを選択してください');
       return;
     }
-    if (!newSource.sourceId || newSource.sourceId.trim() === '') {
-      message.error('source名を入力してください');
+
+    const sourceIdResult = validateSourceId(newSource.sourceId);
+    if (!sourceIdResult.valid) {
+      newErrors.sourceId = sourceIdResult.message;
+    }
+
+    // URL バリデーション
+    if (newSource.url && newSource.type !== 'video') {
+      const urlResult = validateUrl(newSource.url);
+      if (!urlResult.valid) {
+        newErrors.url = urlResult.message;
+      }
+    }
+
+    // tiles バリデーション
+    if (Array.isArray(newSource.tiles) && newSource.tiles.length > 0) {
+      for (const tile of newSource.tiles) {
+        const tileResult = validateTileUrl(tile);
+        if (!tileResult.valid) {
+          newErrors.tiles = tileResult.message;
+          break;
+        }
+      }
+    }
+
+    // minzoom バリデーション
+    const minzoomResult = validateZoomLevel(newSource.minzoom);
+    if (!minzoomResult.valid) {
+      newErrors.minzoom = minzoomResult.message;
+    }
+
+    // maxzoom バリデーション
+    const maxzoomResult = validateZoomLevel(newSource.maxzoom);
+    if (!maxzoomResult.valid) {
+      newErrors.maxzoom = maxzoomResult.message;
+    }
+
+    // minzoom <= maxzoom チェック
+    if (newSource.minzoom !== undefined && newSource.maxzoom !== undefined
+      && !newErrors.minzoom && !newErrors.maxzoom
+      && newSource.minzoom > newSource.maxzoom) {
+      newErrors.minzoom = 'minzoomはmaxzoom以下にしてください';
+    }
+
+    if (Object.values(newErrors).some(Boolean)) {
+      setErrors(newErrors);
       return;
     }
+
     const { sourceId, ...sourceSpec } = newSource;
-    console.log('追加するソース:', sourceId, sourceSpec, newSource);
     onOk(sourceId, sourceSpec as SourceSpecification);
     setNewSource(initialState);
+    setErrors({});
   };
 
   return (
@@ -58,18 +119,23 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
       onOk={handleOk}
       onCancel={() => {
         setNewSource(initialState);
+        setErrors({});
         onCancel();
       }}
       okText="追加"
       title="新しいソースを追加"
     >
       <Space direction="vertical" style={{ width: '100%' }} size="small">
-        <Input
-          addonBefore="source名"
-          placeholder="source名を入力"
-          value={newSource.sourceId}
-          onChange={e => handleChange('sourceId', e.target.value)}
-        />
+        <div>
+          <Input
+            addonBefore="source名"
+            placeholder="source名を入力"
+            value={newSource.sourceId}
+            onChange={e => handleChange('sourceId', e.target.value)}
+            status={errors.sourceId ? 'error' : undefined}
+          />
+          {errors.sourceId && <Text type="danger" style={{ fontSize: 12 }}>{errors.sourceId}</Text>}
+        </div>
         <div>
           <label>type</label>
           <Select
@@ -81,27 +147,35 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
           />
         </div>
         {(newSource.type !== 'video') && (
-          <Input
-            addonBefore={newSource.type === 'geojson' ? "data" : "url"}
-            placeholder={"url" + (newSource.type === 'geojson' ? "またはdataを指定" : "")}
-            value={newSource.url ?? ''}
-            onChange={e => handleChange('url', e.target.value)}
-          />
+          <div>
+            <Input
+              addonBefore={newSource.type === 'geojson' ? "data" : "url"}
+              placeholder={"url" + (newSource.type === 'geojson' ? "またはdataを指定" : "")}
+              value={newSource.url ?? ''}
+              onChange={e => handleChange('url', e.target.value)}
+              status={errors.url ? 'error' : undefined}
+            />
+            {errors.url && <Text type="danger" style={{ fontSize: 12 }}>{errors.url}</Text>}
+          </div>
         )}
         {(newSource.type !== 'geojson' && newSource.type !== 'image') && (
-          <Input
-            addonBefore={newSource.type === 'video' ? "urls" : "tiles"}
-            placeholder="カンマ区切りで複数指定"
-            value={Array.isArray(newSource.tiles) ? newSource.tiles.join(',') : ''}
-            onChange={e =>
-              handleChange(
-                'tiles',
-                e.target.value
-                  ? e.target.value.split(',').map((s: string) => s.trim()).filter(Boolean)
-                  : []
-              )
-            }
-          />
+          <div>
+            <Input
+              addonBefore={newSource.type === 'video' ? "urls" : "tiles"}
+              placeholder="カンマ区切りで複数指定"
+              value={Array.isArray(newSource.tiles) ? newSource.tiles.join(',') : ''}
+              onChange={e =>
+                handleChange(
+                  'tiles',
+                  e.target.value
+                    ? e.target.value.split(',').map((s: string) => s.trim()).filter(Boolean)
+                    : []
+                )
+              }
+              status={errors.tiles ? 'error' : undefined}
+            />
+            {errors.tiles && <Text type="danger" style={{ fontSize: 12 }}>{errors.tiles}</Text>}
+          </div>
         )}
         <Input
           addonBefore="attribution"
@@ -109,20 +183,28 @@ const AddSourceModal: React.FC<AddSourceModalProps> = ({ open, onOk, onCancel })
           value={newSource.attribution ?? ''}
           onChange={e => handleChange('attribution', e.target.value)}
         />
-        <Input
-          addonBefore="minzoom"
-          placeholder="minzoom"
-          type="number"
-          value={newSource.minzoom ?? ''}
-          onChange={e => handleChange('minzoom', e.target.value === '' ? undefined : Number(e.target.value))}
-        />
-        <Input
-          addonBefore="maxzoom"
-          placeholder="maxzoom"
-          type="number"
-          value={newSource.maxzoom ?? ''}
-          onChange={e => handleChange('maxzoom', e.target.value === '' ? undefined : Number(e.target.value))}
-        />
+        <div>
+          <Input
+            addonBefore="minzoom"
+            placeholder="minzoom (0〜24)"
+            type="number"
+            value={newSource.minzoom ?? ''}
+            onChange={e => handleChange('minzoom', e.target.value === '' ? undefined : Number(e.target.value))}
+            status={errors.minzoom ? 'error' : undefined}
+          />
+          {errors.minzoom && <Text type="danger" style={{ fontSize: 12 }}>{errors.minzoom}</Text>}
+        </div>
+        <div>
+          <Input
+            addonBefore="maxzoom"
+            placeholder="maxzoom (0〜24)"
+            type="number"
+            value={newSource.maxzoom ?? ''}
+            onChange={e => handleChange('maxzoom', e.target.value === '' ? undefined : Number(e.target.value))}
+            status={errors.maxzoom ? 'error' : undefined}
+          />
+          {errors.maxzoom && <Text type="danger" style={{ fontSize: 12 }}>{errors.maxzoom}</Text>}
+        </div>
       </Space>
     </Modal>
   );

--- a/src/components/BasicInfo/BasicInfo.tsx
+++ b/src/components/BasicInfo/BasicInfo.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import { Input, Button, Form, Space, message, Card } from 'antd';
 import { useAtom } from 'jotai';
 import { styleAtom } from '../../atom';
+import { validateCoordinates, validateZoomLevel } from '../../lib/validators';
 
 const BasicInfo: React.FC = () => {
     const [style, setStyle] = useAtom(styleAtom);
@@ -52,10 +53,30 @@ const BasicInfo: React.FC = () => {
                 <Form.Item label="スタイル名" name="name">
                     <Input placeholder="style.jsonのname" />
                 </Form.Item>
-                <Form.Item label="中心座標(center)" name="center">
+                <Form.Item
+                    label="中心座標(center)"
+                    name="center"
+                    rules={[{
+                        validator: (_, value) => {
+                            if (!value) return Promise.resolve();
+                            const result = validateCoordinates(value);
+                            return result.valid ? Promise.resolve() : Promise.reject(new Error(result.message));
+                        }
+                    }]}
+                >
                     <Input placeholder="例: 139.767,35.681" />
                 </Form.Item>
-                <Form.Item label="ズーム(zoom)" name="zoom">
+                <Form.Item
+                    label="ズーム(zoom)"
+                    name="zoom"
+                    rules={[{
+                        validator: (_, value) => {
+                            if (value === '' || value === undefined || value === null) return Promise.resolve();
+                            const result = validateZoomLevel(Number(value));
+                            return result.valid ? Promise.resolve() : Promise.reject(new Error(result.message));
+                        }
+                    }]}
+                >
                     <Input type="number" placeholder="例: 10" />
                 </Form.Item>
                 <Form.Item>

--- a/src/components/LayerList/LayerDetailAccordion.tsx
+++ b/src/components/LayerList/LayerDetailAccordion.tsx
@@ -3,6 +3,7 @@ import { Collapse, Flex, Tooltip, Button, Input, Typography } from 'antd';
 import { EditOutlined, CheckOutlined, CloseOutlined, ReloadOutlined } from '@ant-design/icons';
 import type { LayerSpecification } from 'maplibre-gl';
 import { useColorfulJson } from '../../utils/renderColorfulJson';
+import { validateJson } from '../../lib/validators';
 
 const { Text } = Typography;
 
@@ -19,6 +20,7 @@ const LayerDetailAccordion: React.FC<Props> = ({ layer, editing, onEdit, onReset
   const [localValue, setLocalValue] = useState<string>('');
   const [localEditing, setLocalEditing] = useState<{ layerId: string; field: 'filter' | 'paint' | 'layout' | null } | null>(null);
   const [activeKey, setActiveKey] = useState<string[]>([]);
+  const [jsonError, setJsonError] = useState<string | undefined>(undefined);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const jsonStr = JSON.stringify((layer as any)['paint'], null, 2) || '';
@@ -26,11 +28,18 @@ const LayerDetailAccordion: React.FC<Props> = ({ layer, editing, onEdit, onReset
 
   const handleSave = (e: React.MouseEvent<HTMLElement>, field: 'filter' | 'paint' | 'layout', localValue: string) => {
     e.stopPropagation();
+    const result = validateJson(localValue);
+    if (!result.valid) {
+      setJsonError(result.message);
+      return;
+    }
+    setJsonError(undefined);
     onSave(field, localValue);
   };
 
   const handleCancel = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
+    setJsonError(undefined);
     onCancel();
   };
 
@@ -110,12 +119,16 @@ const LayerDetailAccordion: React.FC<Props> = ({ layer, editing, onEdit, onReset
       </Flex>
     ),
     children: localEditing?.layerId === layer.id && localEditing?.field === field ? (
-      <Input.TextArea
-        value={localValue}
-        onChange={e => setLocalValue(e.target.value)}
-        autoSize={{ minRows: 4 }}
-        style={{ backgroundColor: '#fbfbfb' }}
-      />
+      <div>
+        <Input.TextArea
+          value={localValue}
+          onChange={e => { setLocalValue(e.target.value); setJsonError(undefined); }}
+          autoSize={{ minRows: 4 }}
+          style={{ backgroundColor: '#fbfbfb' }}
+          status={jsonError ? 'error' : undefined}
+        />
+        {jsonError && <Text type="danger" style={{ fontSize: 12, display: 'block', marginTop: 4 }}>{jsonError}</Text>}
+      </div>
     ) : (
       <pre style={{ whiteSpace: 'pre-wrap' }}>
         {

--- a/src/components/LayerList/LayerList.tsx
+++ b/src/components/LayerList/LayerList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Input, Spin } from 'antd';
+import { Input, Spin, message } from 'antd';
 import { useAtom, useAtomValue } from 'jotai';
 import { mapAtom, styleAtom } from '../../atom';
 import { groupLayersByType } from '../../utils/layerControl';
@@ -10,6 +10,7 @@ import {
   type RowComponentProps
 } from "react-window";
 import type { EditingType, FieldType } from './LayerList.types';
+import { validateJson } from '../../lib/validators';
 import './LayerList.css';
 
 
@@ -108,6 +109,14 @@ const LayerList: React.FC<LayerListProps> = ({ savePrevStyle, addLayer }) => {
     // 編集保存
     const handleSave = useCallback((layerId: string, field: 'filter' | 'paint' | 'layout', value: string) => {
         if (typeof style === 'string') { return; }
+        // JSON バリデーション
+        if (value) {
+            const jsonResult = validateJson(value);
+            if (!jsonResult.valid) {
+                message.error(jsonResult.message ?? 'JSONの形式が正しくありません');
+                return;
+            }
+        }
         try {
             const newValue = value ? JSON.parse(value) : undefined;
             const nowLngLat = map?.getCenter()

--- a/src/components/SourceEditor/SourceEditor.tsx
+++ b/src/components/SourceEditor/SourceEditor.tsx
@@ -5,6 +5,7 @@ import { useAtom } from 'jotai';
 import { styleAtom } from '../../atom';
 import type { LayerSpecification, SourceSpecification, StyleSpecification } from 'maplibre-gl';
 import AddSourceModal from '../AddSourceModal/AddSourceModal';
+import { validateUrl, validateTileUrl, validateZoomLevel } from '../../lib/validators';
 
 type SourcesProps = {
   savePrevStyle: (newStyle: maplibregl.StyleSpecification | undefined) => void;
@@ -21,6 +22,8 @@ const SOURCE_TYPES = [
   { label: 'video', value: 'video' },
 ];
 
+type SourceErrors = Record<string, { url?: string; tiles?: string; minzoom?: string; maxzoom?: string }>;
+
 const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
   const [style, setStyle] = useAtom(styleAtom);
   const [modalOpen, setModalOpen] = useState(false);
@@ -28,6 +31,7 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
   const [targetSourceId, setTargetSourceId] = useState<string | null>(null);
   const [referencedLayers, setReferencedLayers] = useState<LayerSpecification[]>([]);
   const [editSources, setEditSources] = useState<Record<string, Partial<SourceSpecification & { url?: string, attribution?: string, tiles?: string[] }>>>({});
+  const [sourceErrors, setSourceErrors] = useState<SourceErrors>({});
 
   // sourcesを取得
   const sources = useMemo(() => (typeof style === 'object' && style?.sources) ?? {}, [style]);
@@ -47,6 +51,11 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
       ...prev,
       [sourceId]: { ...prev[sourceId], [key]: value }
     }));
+    // 入力時にそのフィールドのエラーをクリア
+    setSourceErrors(prev => ({
+      ...prev,
+      [sourceId]: { ...prev[sourceId], [key]: undefined }
+    }));
   };
 
   // 保存
@@ -56,6 +65,48 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
         message.error('スタイルが正しく読み込まれていません');
         return;
       }
+
+      // バリデーション
+      const newErrors: SourceErrors = {};
+      let hasError = false;
+      Object.entries(editSources).forEach(([id, src]) => {
+        const errs: SourceErrors[string] = {};
+        // URL バリデーション
+        if (src.url) {
+          const urlResult = validateUrl(src.url);
+          if (!urlResult.valid) { errs.url = urlResult.message; hasError = true; }
+        }
+        // tiles バリデーション
+        if (src.tiles && Array.isArray(src.tiles)) {
+          for (const tile of src.tiles) {
+            const tileResult = validateTileUrl(tile);
+            if (!tileResult.valid) { errs.tiles = tileResult.message; hasError = true; break; }
+          }
+        }
+        // minzoom バリデーション
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const minzoom = (src as any).minzoom;
+        const minzoomResult = validateZoomLevel(minzoom);
+        if (!minzoomResult.valid) { errs.minzoom = minzoomResult.message; hasError = true; }
+        // maxzoom バリデーション
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const maxzoom = (src as any).maxzoom;
+        const maxzoomResult = validateZoomLevel(maxzoom);
+        if (!maxzoomResult.valid) { errs.maxzoom = maxzoomResult.message; hasError = true; }
+        // minzoom <= maxzoom
+        if (minzoom !== undefined && maxzoom !== undefined && !errs.minzoom && !errs.maxzoom && minzoom > maxzoom) {
+          errs.minzoom = 'minzoomはmaxzoom以下にしてください';
+          hasError = true;
+        }
+        if (Object.keys(errs).length > 0) newErrors[id] = errs;
+      });
+
+      if (hasError) {
+        setSourceErrors(newErrors);
+        message.error('入力内容にエラーがあります');
+        return;
+      }
+
       const newSources: Record<string, SourceSpecification> = {};
       Object.entries(editSources).forEach(([id, src]) => {
         // type, url, attribution など必要な項目のみ
@@ -70,6 +121,7 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
       const newStyle = { ...style!, sources: newSources };
       savePrevStyle(style);
       setStyle(newStyle);
+      setSourceErrors({});
       message.success('sourcesを保存しました');
     } catch {
       message.error('保存に失敗しました');
@@ -187,28 +239,36 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
                     />
                   </div>
                   {source.tiles && Array.isArray(source.tiles) && source.tiles.length > 0 ? (
-                    <Input
-                      addonBefore="tiles"
-                      placeholder="tiles（カンマ区切り可）"
-                      value={Array.isArray(source.tiles) ? source.tiles.join(',') : ''}
-                      onChange={e =>
-                        handleChange(
-                          sourceId,
-                          'tiles',
-                          e.target.value
-                            ? e.target.value.split(',').map(s => s.trim()).filter(Boolean)
-                            : undefined
-                        )
-                      }
-                    />
+                    <div>
+                      <Input
+                        addonBefore="tiles"
+                        placeholder="tiles（カンマ区切り可）"
+                        value={Array.isArray(source.tiles) ? source.tiles.join(',') : ''}
+                        onChange={e =>
+                          handleChange(
+                            sourceId,
+                            'tiles',
+                            e.target.value
+                              ? e.target.value.split(',').map(s => s.trim()).filter(Boolean)
+                              : undefined
+                          )
+                        }
+                        status={sourceErrors[sourceId]?.tiles ? 'error' : undefined}
+                      />
+                      {sourceErrors[sourceId]?.tiles && <Text type="danger" style={{ fontSize: 12 }}>{sourceErrors[sourceId].tiles}</Text>}
+                    </div>
                   ) : (
                     (!source.type || source.type !== 'geojson') && (
-                      <Input
-                        addonBefore="url"
-                        placeholder="url"
-                        value={(source as Partial<SourceSpecification & { url?: string }>).url ?? ''}
-                        onChange={e => handleChange(sourceId, 'url', e.target.value)}
-                      />
+                      <div>
+                        <Input
+                          addonBefore="url"
+                          placeholder="url"
+                          value={(source as Partial<SourceSpecification & { url?: string }>).url ?? ''}
+                          onChange={e => handleChange(sourceId, 'url', e.target.value)}
+                          status={sourceErrors[sourceId]?.url ? 'error' : undefined}
+                        />
+                        {sourceErrors[sourceId]?.url && <Text type="danger" style={{ fontSize: 12 }}>{sourceErrors[sourceId].url}</Text>}
+                      </div>
                     )
                   )
                   }
@@ -218,22 +278,30 @@ const SourceEditor: React.FC<SourcesProps> = ({ savePrevStyle }) => {
                     value={source.attribution ?? ''}
                     onChange={e => handleChange(sourceId, 'attribution', e.target.value)}
                   />
-                  <Input
-                    addonBefore="minzoom"
-                    placeholder="minzoom"
-                    type="number"
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    value={(source as any).minzoom ?? ''}
-                    onChange={e => handleChange(sourceId, 'minzoom', e.target.value === '' ? undefined : Number(e.target.value))}
-                  />
-                  <Input
-                    addonBefore="maxzoom"
-                    placeholder="maxzoom"
-                    type="number"
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    value={(source as any).maxzoom ?? ''}
-                    onChange={e => handleChange(sourceId, 'maxzoom', e.target.value === '' ? undefined : Number(e.target.value))}
-                  />
+                  <div>
+                    <Input
+                      addonBefore="minzoom"
+                      placeholder="minzoom (0〜24)"
+                      type="number"
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      value={(source as any).minzoom ?? ''}
+                      onChange={e => handleChange(sourceId, 'minzoom', e.target.value === '' ? undefined : Number(e.target.value))}
+                      status={sourceErrors[sourceId]?.minzoom ? 'error' : undefined}
+                    />
+                    {sourceErrors[sourceId]?.minzoom && <Text type="danger" style={{ fontSize: 12 }}>{sourceErrors[sourceId].minzoom}</Text>}
+                  </div>
+                  <div>
+                    <Input
+                      addonBefore="maxzoom"
+                      placeholder="maxzoom (0〜24)"
+                      type="number"
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      value={(source as any).maxzoom ?? ''}
+                      onChange={e => handleChange(sourceId, 'maxzoom', e.target.value === '' ? undefined : Number(e.target.value))}
+                      status={sourceErrors[sourceId]?.maxzoom ? 'error' : undefined}
+                    />
+                    {sourceErrors[sourceId]?.maxzoom && <Text type="danger" style={{ fontSize: 12 }}>{sourceErrors[sourceId].maxzoom}</Text>}
+                  </div>
                 </Space>
               </Space>
             );

--- a/src/components/StyleJsonViewer/StyleJsonViewer.tsx
+++ b/src/components/StyleJsonViewer/StyleJsonViewer.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
-import { Button, Card, Input, message, Space, Tooltip } from 'antd';
+import { Button, Card, Input, message, Space, Tooltip, Typography } from 'antd';
 import { useAtom } from 'jotai';
 import { styleAtom } from '../../atom';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { CheckOutlined, CloseOutlined, EditOutlined } from '@ant-design/icons';
+import { validateJson } from '../../lib/validators';
+
+const { Text } = Typography;
 
 type StyleJsonViewerProps = {
     savePrevStyle: (newStyle: maplibregl.StyleSpecification | undefined) => void
@@ -14,27 +17,38 @@ const StyleJsonViewer: React.FC<StyleJsonViewerProps> = ({ savePrevStyle }) => {
   const [style, setStyle] = useAtom(styleAtom);
   const [editing, setEditing] = useState(false);
   const [code, setCode] = useState(() => JSON.stringify(style, null, 2));
+  const [jsonError, setJsonError] = useState<string | undefined>(undefined);
 
   // 編集モード切替時に最新のstyleを反映
   const handleEdit = () => {
     setCode(JSON.stringify(style, null, 2));
+    setJsonError(undefined);
     setEditing(true);
   };
 
   const handleSave = () => {
+    const result = validateJson(code);
+    if (!result.valid) {
+      setJsonError(result.message);
+      message.error(result.message ?? 'JSONの形式が正しくありません');
+      return;
+    }
     try {
       const parsed = JSON.parse(code);
       setStyle(parsed);
       setEditing(false);
+      setJsonError(undefined);
       message.success('style.jsonを更新しました');
       savePrevStyle(parsed);
     } catch {
+      setJsonError('JSONの形式が正しくありません');
       message.error('JSONの形式が正しくありません');
     }
   };
 
   const handleCancel = () => {
     setCode(JSON.stringify(style, null, 2));
+    setJsonError(undefined);
     setEditing(false);
   };
 
@@ -73,18 +87,22 @@ const StyleJsonViewer: React.FC<StyleJsonViewerProps> = ({ savePrevStyle }) => {
       }</Space>
       <div style={{ width: '100%', maxHeight: 'calc(100% - 40px)', overflowY: 'scroll' }}>
         {editing ? (
-          <Input.TextArea
-            value={code}
-            onChange={e => setCode(e.target.value)}
-            autoSize={{ minRows: 20 }}
-            style={{
-              width: '100%',
-              fontSize: 14,
-              background: '#1e1e1e',
-              color: '#fff',
-              border: 'none',
-            }}
-          />
+          <div>
+            {jsonError && <Text type="danger" style={{ fontSize: 12, display: 'block', marginBottom: 4, padding: '0 4px' }}>{jsonError}</Text>}
+            <Input.TextArea
+              value={code}
+              onChange={e => { setCode(e.target.value); setJsonError(undefined); }}
+              autoSize={{ minRows: 20 }}
+              status={jsonError ? 'error' : undefined}
+              style={{
+                width: '100%',
+                fontSize: 14,
+                background: '#1e1e1e',
+                color: '#fff',
+                border: 'none',
+              }}
+            />
+          </div>
         ) : (
           <SyntaxHighlighter language="json" style={vscDarkPlus}>
             {JSON.stringify(style, null, 2)}

--- a/src/components/StyleUrlLoader/StyleUrlLoader.tsx
+++ b/src/components/StyleUrlLoader/StyleUrlLoader.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useRef } from 'react';
-import { Input, Button, Space, message, type InputRef } from 'antd';
+import { Input, Button, Space, message, Typography, type InputRef } from 'antd';
 import { useAtom } from 'jotai';
 import { styleAtom } from '../../atom';
+import { validateUrl } from '../../lib/validators';
 import './StyleUrlLoader.css';
+
+const { Text } = Typography;
 
 const HISTORY_KEY = 'styleUrlHistory';
 
@@ -27,12 +30,24 @@ const StyleUrlLoader: React.FC<Props> = ({ setLoadError }) => {
   const [loading, setLoading] = useState(false);
   const [history, setHistoryState] = useState<string[]>(getHistory());
   const [historyVisible, setHistoryVisible] = useState(false);
+  const [urlError, setUrlError] = useState<string | undefined>(undefined);
   const inputRef = useRef<InputRef>(null);
 
   const handleLoad = async () => {
-    if (!url || url.trim() === '' || !/\.json(\?.*)?$/i.test(url.trim())) {
+    if (!url || url.trim() === '') {
       message.warning('URLを入力してください');
       setUrl('');
+      setLoadError(true);
+      return;
+    }
+    const urlResult = validateUrl(url.trim());
+    if (!urlResult.valid) {
+      setUrlError(urlResult.message);
+      setLoadError(true);
+      return;
+    }
+    if (!/\.json(\?.*)?$/i.test(url.trim())) {
+      setUrlError('URLは .json で終わる必要があります');
       setLoadError(true);
       return;
     }
@@ -74,7 +89,7 @@ const StyleUrlLoader: React.FC<Props> = ({ setLoadError }) => {
         <Input
           ref={inputRef}
           value={url}
-          onChange={e => setUrl(e.target.value)}
+          onChange={e => { setUrl(e.target.value); setUrlError(undefined); }}
           placeholder="URL指定でstyleを読み込む"
           disabled={loading}
           className="style-url-loader-input"
@@ -82,6 +97,7 @@ const StyleUrlLoader: React.FC<Props> = ({ setLoadError }) => {
           onFocus={handleInputFocus}
           onBlur={handleInputBlur}
           autoComplete="off"
+          status={urlError ? 'error' : undefined}
         />
         <Button
           type="primary"
@@ -92,6 +108,7 @@ const StyleUrlLoader: React.FC<Props> = ({ setLoadError }) => {
           読み込む
         </Button>
       </Space.Compact>
+      {urlError && <Text type="danger" style={{ fontSize: 12, display: 'block', marginTop: 2 }}>{urlError}</Text>}
       {historyVisible && history.length > 0 && (
         <div className="style-url-loader-history-dropdown">
           {history.map((h, i) => (

--- a/src/lib/__tests__/validators.test.ts
+++ b/src/lib/__tests__/validators.test.ts
@@ -1,0 +1,218 @@
+import {
+  validateUrl,
+  validateTileUrl,
+  validateJson,
+  validateZoomLevel,
+  validateCoordinates,
+  validateSourceId,
+  validateLayerId,
+  validateOpacity,
+  type ValidationResult,
+} from '../validators';
+
+// ヘルパー: 成功結果の検証
+const expectValid = (result: ValidationResult) => {
+  expect(result.valid).toBe(true);
+  expect(result.message).toBeUndefined();
+};
+
+// ヘルパー: 失敗結果の検証
+const expectInvalid = (result: ValidationResult, messagePart?: string) => {
+  expect(result.valid).toBe(false);
+  expect(result.message).toBeDefined();
+  if (messagePart) {
+    expect(result.message).toContain(messagePart);
+  }
+};
+
+describe('validateUrl', () => {
+  it('有効なHTTPS URLを受け入れる', () => {
+    expectValid(validateUrl('https://example.com/style.json'));
+  });
+
+  it('有効なHTTP URLを受け入れる', () => {
+    expectValid(validateUrl('http://example.com/tiles/{z}/{x}/{y}.pbf'));
+  });
+
+  it('空文字列を許可する（任意入力の場合）', () => {
+    expectValid(validateUrl(''));
+  });
+
+  it('無効なURLを拒否する', () => {
+    expectInvalid(validateUrl('not-a-url'), 'URL');
+  });
+
+  it('プロトコルなしのURLを拒否する', () => {
+    expectInvalid(validateUrl('example.com/style.json'), 'URL');
+  });
+
+  it('空白のみの文字列を拒否する', () => {
+    expectInvalid(validateUrl('   '), 'URL');
+  });
+});
+
+describe('validateTileUrl', () => {
+  it('有効なタイルURLを受け入れる', () => {
+    expectValid(validateTileUrl('https://example.com/tiles/{z}/{x}/{y}.pbf'));
+  });
+
+  it('空文字列を許可する', () => {
+    expectValid(validateTileUrl(''));
+  });
+
+  it('無効なURLを拒否する', () => {
+    expectInvalid(validateTileUrl('not-a-url'), 'URL');
+  });
+
+  it('mapbox://プロトコルを受け入れる', () => {
+    expectValid(validateTileUrl('mapbox://mapbox.mapbox-streets-v8'));
+  });
+});
+
+describe('validateJson', () => {
+  it('有効なJSONオブジェクトを受け入れる', () => {
+    expectValid(validateJson('{"circle-color": "#ff0000"}'));
+  });
+
+  it('有効なJSON配列を受け入れる', () => {
+    expectValid(validateJson('["==", "class", "A"]'));
+  });
+
+  it('空文字列を許可する', () => {
+    expectValid(validateJson(''));
+  });
+
+  it('無効なJSONを拒否する', () => {
+    expectInvalid(validateJson('{invalid json}'), 'JSON');
+  });
+
+  it('文字列のみのJSONを拒否する（オブジェクトか配列が必要）', () => {
+    expectInvalid(validateJson('"just a string"'), 'オブジェクトまたは配列');
+  });
+
+  it('数値のみのJSONを拒否する', () => {
+    expectInvalid(validateJson('42'), 'オブジェクトまたは配列');
+  });
+
+  it('nullを受け入れる（フィルタのリセット等）', () => {
+    expectValid(validateJson('null'));
+  });
+});
+
+describe('validateZoomLevel', () => {
+  it('有効なズームレベル(0)を受け入れる', () => {
+    expectValid(validateZoomLevel(0));
+  });
+
+  it('有効なズームレベル(24)を受け入れる', () => {
+    expectValid(validateZoomLevel(24));
+  });
+
+  it('有効なズームレベル(10.5)を受け入れる', () => {
+    expectValid(validateZoomLevel(10.5));
+  });
+
+  it('undefinedを許可する（任意入力）', () => {
+    expectValid(validateZoomLevel(undefined));
+  });
+
+  it('負の値を拒否する', () => {
+    expectInvalid(validateZoomLevel(-1), '0');
+  });
+
+  it('24を超える値を拒否する', () => {
+    expectInvalid(validateZoomLevel(25), '24');
+  });
+
+  it('NaNを拒否する', () => {
+    expectInvalid(validateZoomLevel(NaN), '数値');
+  });
+});
+
+describe('validateCoordinates', () => {
+  it('有効な座標を受け入れる', () => {
+    expectValid(validateCoordinates('139.767,35.681'));
+  });
+
+  it('空文字列を許可する', () => {
+    expectValid(validateCoordinates(''));
+  });
+
+  it('スペースを含む座標を受け入れる', () => {
+    expectValid(validateCoordinates('139.767, 35.681'));
+  });
+
+  it('カンマが含まれない文字列を拒否する', () => {
+    expectInvalid(validateCoordinates('139.767'), '経度,緯度');
+  });
+
+  it('数値でない値を拒否する', () => {
+    expectInvalid(validateCoordinates('abc,def'), '数値');
+  });
+
+  it('経度の範囲外を拒否する', () => {
+    expectInvalid(validateCoordinates('200,35'), '経度');
+  });
+
+  it('緯度の範囲外を拒否する', () => {
+    expectInvalid(validateCoordinates('139,100'), '緯度');
+  });
+});
+
+describe('validateSourceId', () => {
+  it('有効なソースIDを受け入れる', () => {
+    expectValid(validateSourceId('my-source'));
+  });
+
+  it('空文字列を拒否する', () => {
+    expectInvalid(validateSourceId(''), 'ソース名');
+  });
+
+  it('空白のみを拒否する', () => {
+    expectInvalid(validateSourceId('   '), 'ソース名');
+  });
+});
+
+describe('validateLayerId', () => {
+  it('有効なレイヤーIDを受け入れる', () => {
+    expectValid(validateLayerId('my-layer'));
+  });
+
+  it('空文字列を拒否する', () => {
+    expectInvalid(validateLayerId(''), 'レイヤーID');
+  });
+
+  it('空白のみを拒否する', () => {
+    expectInvalid(validateLayerId('   '), 'レイヤーID');
+  });
+});
+
+describe('validateOpacity', () => {
+  it('有効な不透明度(0)を受け入れる', () => {
+    expectValid(validateOpacity(0));
+  });
+
+  it('有効な不透明度(1)を受け入れる', () => {
+    expectValid(validateOpacity(1));
+  });
+
+  it('有効な不透明度(0.5)を受け入れる', () => {
+    expectValid(validateOpacity(0.5));
+  });
+
+  it('undefinedを許可する', () => {
+    expectValid(validateOpacity(undefined));
+  });
+
+  it('負の値を拒否する', () => {
+    expectInvalid(validateOpacity(-0.1), '0');
+  });
+
+  it('1を超える値を拒否する', () => {
+    expectInvalid(validateOpacity(1.1), '1');
+  });
+
+  it('NaNを拒否する', () => {
+    expectInvalid(validateOpacity(NaN), '数値');
+  });
+});

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,139 @@
+/**
+ * 入力値バリデーションユーティリティ
+ *
+ * 各入力フィールドで共通的に使えるバリデーション関数群。
+ * すべての関数は { valid, message? } を返す。
+ */
+
+export type ValidationResult = {
+  valid: boolean;
+  message?: string;
+};
+
+const ok = (): ValidationResult => ({ valid: true });
+const ng = (message: string): ValidationResult => ({ valid: false, message });
+
+/**
+ * URL バリデーション
+ * 空文字は許可（任意入力向け）。空白のみや無効な形式は拒否。
+ */
+export function validateUrl(value: string): ValidationResult {
+  if (value === '') return ok();
+  const trimmed = value.trim();
+  if (trimmed === '') return ng('有効なURLを入力してください');
+  try {
+    new URL(trimmed);
+    return ok();
+  } catch {
+    return ng('有効なURLを入力してください');
+  }
+}
+
+/**
+ * タイルURL バリデーション
+ * 通常のURL形式に加え、mapbox:// プロトコルも許可する。
+ */
+export function validateTileUrl(value: string): ValidationResult {
+  if (value === '') return ok();
+  const trimmed = value.trim();
+  if (trimmed === '') return ng('有効なURLを入力してください');
+  // mapbox:// 等のカスタムプロトコルを許可
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return ok();
+  }
+  return ng('有効なURLを入力してください');
+}
+
+/**
+ * JSON バリデーション
+ * 空文字と null は許可。パース後はオブジェクトまたは配列であること。
+ */
+export function validateJson(value: string): ValidationResult {
+  if (value === '') return ok();
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed === null) return ok();
+    if (typeof parsed !== 'object') {
+      return ng('JSONはオブジェクトまたは配列である必要があります');
+    }
+    return ok();
+  } catch {
+    return ng('JSON の形式が正しくありません');
+  }
+}
+
+/**
+ * ズームレベル バリデーション (0-24)
+ * undefined は許可（任意入力向け）。
+ */
+export function validateZoomLevel(value: number | undefined): ValidationResult {
+  if (value === undefined) return ok();
+  if (typeof value !== 'number' || isNaN(value)) {
+    return ng('有効な数値を入力してください');
+  }
+  if (value < 0 || value > 24) {
+    return ng('ズームレベルは0〜24の範囲で入力してください');
+  }
+  return ok();
+}
+
+/**
+ * 座標 バリデーション (経度,緯度)
+ * 空文字は許可。「経度,緯度」形式でそれぞれ範囲チェック。
+ */
+export function validateCoordinates(value: string): ValidationResult {
+  if (value === '') return ok();
+  const parts = value.split(',');
+  if (parts.length !== 2) {
+    return ng('「経度,緯度」の形式で入力してください');
+  }
+  const lng = Number(parts[0].trim());
+  const lat = Number(parts[1].trim());
+  if (isNaN(lng) || isNaN(lat)) {
+    return ng('経度・緯度には数値を入力してください');
+  }
+  if (lng < -180 || lng > 180) {
+    return ng('経度は-180〜180の範囲で入力してください');
+  }
+  if (lat < -90 || lat > 90) {
+    return ng('緯度は-90〜90の範囲で入力してください');
+  }
+  return ok();
+}
+
+/**
+ * ソースID バリデーション
+ * 空文字・空白のみは拒否。
+ */
+export function validateSourceId(value: string): ValidationResult {
+  if (!value || value.trim() === '') {
+    return ng('ソース名を入力してください');
+  }
+  return ok();
+}
+
+/**
+ * レイヤーID バリデーション
+ * 空文字・空白のみは拒否。
+ */
+export function validateLayerId(value: string): ValidationResult {
+  if (!value || value.trim() === '') {
+    return ng('レイヤーIDを入力してください');
+  }
+  return ok();
+}
+
+/**
+ * 不透明度 バリデーション (0-1)
+ * undefined は許可。
+ */
+export function validateOpacity(value: number | undefined): ValidationResult {
+  if (value === undefined) return ok();
+  if (typeof value !== 'number' || isNaN(value)) {
+    return ng('有効な数値を入力してください');
+  }
+  if (value < 0 || value > 1) {
+    return ng('不透明度は0〜1の範囲で入力してください');
+  }
+  return ok();
+}


### PR DESCRIPTION
## Summary
- `src/lib/validators.ts` にバリデーションユーティリティを新規作成（URL, JSON, ズームレベル, 座標, ソースID, レイヤーID, 不透明度）
- 44件のユニットテストを追加（`src/lib/__tests__/validators.test.ts`）
- 8つのコンポーネントにバリデーションを統合し、エラーメッセージをインライン表示

### 対象コンポーネントと追加したバリデーション
| コンポーネント | バリデーション内容 |
|---|---|
| AddSourceModal | ソース名必須、URL形式、タイルURL形式、minzoom/maxzoom範囲(0-24)、minzoom<=maxzoom |
| AddLayerModal | filter/paint/layout の JSON 形式チェック |
| SourceEditor | URL形式、タイルURL形式、minzoom/maxzoom範囲(0-24) |
| LayerDetailAccordion | filter/paint/layout の JSON インライン検証 |
| LayerList | JSON 保存時バリデーション |
| StyleJsonViewer | スタイルJSON 編集時のインライン検証 |
| StyleUrlLoader | URL 形式 + .json 拡張子チェック |
| BasicInfo | 座標形式・範囲チェック(経度-180~180、緯度-90~90)、ズームレベル範囲チェック(0-24) |

Closes #26

## Test plan
- [x] バリデーションユーティリティの全44テストケースが通ること
- [ ] AddSourceModal で無効なURL/ズームレベルを入力してエラー表示を確認
- [ ] AddLayerModal で不正なJSONを入力してエラー表示を確認
- [ ] StyleJsonViewer で不正なJSONを保存しようとしてエラー表示を確認
- [ ] StyleUrlLoader で無効なURLを入力してエラー表示を確認
- [ ] BasicInfo で不正な座標・ズームレベルを入力してエラー表示を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォーム入力にリアルタイムバリデーション機能を追加しました。URLやズームレベル、JSON形式など各フィールドの入力を自動チェックします。
  * エラーメッセージをフォーム内にインラインで表示するようになりました。無効なデータの送信を防ぎます。

* **テスト**
  * バリデーション機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->